### PR TITLE
Improve timeout handling

### DIFF
--- a/ragelib/brief_rewriter.py
+++ b/ragelib/brief_rewriter.py
@@ -11,7 +11,9 @@ class HTMLBodyWriter():
 
     @staticmethod
     def make_image_element(image_bytes):
-        return f"<img src='data:image/png;base64,{image_bytes}' />"
+        if image_bytes:
+            return f"<img src='data:image/png;base64,{image_bytes}' />"
+        return ""
 
 
     def make_table_element(self, heading_cells, data_cells):

--- a/ragelib/graph_fetcher.py
+++ b/ragelib/graph_fetcher.py
@@ -18,7 +18,7 @@ class ImageFetcher():
 
 
     def get_graph_screenshot(self, url, driver):
-        wait = WebDriverWait(driver, timeout=300)
+        wait = WebDriverWait(driver, timeout=60)
         self.logger.debug(f"Begun fetching url {url}")
         driver.get(url)
 
@@ -36,7 +36,12 @@ class ImageFetcher():
 
     def fetch_images(self):
         for item in tqdm(self.data, desc='Fetching graphs...'):
-            item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], self.driver)
+            try:
+                item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], self.driver)
+            except Exception as e:
+                self.logger.warn("Failed while fetching image for link "+item['graph_link'])
+                print(e)
+                item['graph_bytes'] = None
 
         self.driver.quit()
         return self.data


### PR DESCRIPTION
- Change timeout to 60s (5 mins is too long)
- Catch exceptions when fetching the image and skip (better to get all
images except 1 than crash)

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>