### PR TITLE
Fix race condition on alert presence

### DIFF
--- a/ragelib/image_fetcher.py
+++ b/ragelib/image_fetcher.py
@@ -25,8 +25,8 @@ class ImageFetcher():
         wait.until(expected.visibility_of_element_located((By.ID, 'graph_title')))
         self.logger.debug("Element #graph_title now visible, graph loading")
         
-        if expected.alert_is_present():
-            alert = driver.switch_to.alert
+        alert = expected.alert_is_present()(driver)
+        if alert:
             if "About to plot" in alert.text:
                 alert.accept()
                 self.logger.warn("Many points alert box accepted")


### PR DESCRIPTION
`expected.alert_is_present()` is always true, because it is a Selenium predicate (a `Callable` that expects a web-driver).

This currently raises a NoSuchAlertException.
We have to actually call the expectation with a driver, which will check if an alert is present, or return false (it internally catches this exception), instead of calling switch_to ourselves.

Fixes: 69db96c ("Reorder element checking as to avoid 10s wait for dialogue pop-up")