### PR TITLE
Fix race condition when fetching images

### DIFF
--- a/ragelib/image_fetcher.py
+++ b/ragelib/image_fetcher.py
@@ -46,25 +46,24 @@ class ImageFetcher():
         return canvas_bytes
 
     def fetch_images(self):
-        driver = Firefox(service=self.serv, options=self.options)
-        driver.get("about:blank")
-        orig = driver.current_window_handle
-        for item in tqdm(self.data, desc='Fetching graphs...'):
-            driver.switch_to.new_window('tab')
-            try:
-                item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], driver)
-                item['graph_exception'] = None
-            except TimeoutException:
-                self.logger.warn("Failed while fetching image for link "+item['graph_link'])
-                item['graph_exception'] = "TimeoutException"
-                item['graph_bytes'] = None
-            except Exception as e:
-                self.logger.warn("Failed while fetching image for link "+item['graph_link'])
-                print(e)
-                item['graph_exception'] = str(e)
-                item['graph_bytes'] = None
-            driver.close()
-            # have to switch back, otherwise we can't open new tabs anymore
-            driver.switch_to.window(orig)
-        driver.quit()
+        with Firefox(service=self.serv, options=self.options) as driver:
+            driver.get("about:blank")
+            orig = driver.current_window_handle
+            for item in tqdm(self.data, desc='Fetching graphs...'):
+                driver.switch_to.new_window('tab')
+                try:
+                    item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], driver)
+                    item['graph_exception'] = None
+                except TimeoutException:
+                    self.logger.warn("Failed while fetching image for link "+item['graph_link'])
+                    item['graph_exception'] = "TimeoutException"
+                    item['graph_bytes'] = None
+                except Exception as e:
+                    self.logger.warn("Failed while fetching image for link "+item['graph_link'])
+                    print(e)
+                    item['graph_exception'] = str(e)
+                    item['graph_bytes'] = None
+                driver.close()
+                # have to switch back, otherwise we can't open new tabs anymore
+                driver.switch_to.window(orig)
         return self.data

--- a/ragelib/image_fetcher.py
+++ b/ragelib/image_fetcher.py
@@ -12,12 +12,11 @@ class ImageFetcher():
         self.data = data
         self.logger = logger
 
-        options = Options()
-        options.add_argument('-headless')
+        self.options = Options()
+        self.options.add_argument('-headless')
 
         logger.info(f"Using {geckodriver_path} for geckodriver")
-        serv = Service(geckodriver_path)
-        self.driver = Firefox(service=serv, options=options)
+        self.serv = Service(geckodriver_path)
 
     def get_graph_screenshot(self, url, driver):
         wait = WebDriverWait(driver, timeout=60)
@@ -48,8 +47,9 @@ class ImageFetcher():
 
     def fetch_images(self):
         for item in tqdm(self.data, desc='Fetching graphs...'):
+            driver = Firefox(service=self.serv, options=self.options)
             try:
-                item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], self.driver)
+                item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], driver)
                 item['graph_exception'] = None
             except TimeoutException:
                 self.logger.warn("Failed while fetching image for link "+item['graph_link'])
@@ -60,6 +60,5 @@ class ImageFetcher():
                 print(e)
                 item['graph_exception'] = str(e)
                 item['graph_bytes'] = None
-
-        self.driver.quit()
+            driver.quit()
         return self.data

--- a/ragelib/image_fetcher.py
+++ b/ragelib/image_fetcher.py
@@ -46,8 +46,11 @@ class ImageFetcher():
         return canvas_bytes
 
     def fetch_images(self):
+        driver = Firefox(service=self.serv, options=self.options)
+        driver.get("about:blank")
+        orig = driver.current_window_handle
         for item in tqdm(self.data, desc='Fetching graphs...'):
-            driver = Firefox(service=self.serv, options=self.options)
+            driver.switch_to.new_window('tab')
             try:
                 item['graph_bytes'] = self.get_graph_screenshot(item['graph_link'], driver)
                 item['graph_exception'] = None
@@ -60,5 +63,8 @@ class ImageFetcher():
                 print(e)
                 item['graph_exception'] = str(e)
                 item['graph_bytes'] = None
-            driver.quit()
+            driver.close()
+            # have to switch back, otherwise we can't open new tabs anymore
+            driver.switch_to.window(orig)
+        driver.quit()
         return self.data


### PR DESCRIPTION
ragebot was very fast lately, but also very wrong.
In the past we used to have some WebDriverWait code (that ended up sleeping for a while looking for a popup that wasn't there), however some pages took longer to load than the timeout. The sleeps have been completely removed once we fixed the waiting code, but this has revealed a pre-existing race condition: `driver.get()` doesn't actually guarantee that the page has loaded, and in many cases we have seen the graph from the previous page being saved as the graph for other pages.
In fact only the first 2 graphs were correct, most of the other graphs were a copy of the 2nd one.

I think what was happening that while the new page was loading, any queries for elements on the page found the old one, and concluded that page loading has finished (which wasn't true).

Use new tabs for each graph and completely close them to ensure that nothing remains from the old graph when fetching the new one (fetching is still single-threaded, and was single-threaded before, so this works).

Now ragebot is back to being slow, but it is correct.